### PR TITLE
Don't hide python buffers

### DIFF
--- a/buffer_autohide.py
+++ b/buffer_autohide.py
@@ -117,7 +117,7 @@ def hide_buffer_cb(signal, data, signal_data):
     server = weechat.buffer_get_string(previous_buffer, "localvar_server")
     channel = weechat.buffer_get_string(previous_buffer, "localvar_channel")
 
-    if plugin != "irc" or full_name.startswith("irc.server"):
+    if full_name.startswith("irc.server"):
         return WEECHAT_RC_OK
 
     buffer_type = weechat.buffer_get_string(


### PR DESCRIPTION
This allows us to hide wee-slack.py buffers, which aren't from the IRC plugin.

example infolist output for a python buffer:

```
Infolist 'buffer', with pointer '' and arguments 'python.networktocode.#general':
[1] pointer.......................: ptr 0x6d006f0
current_buffer................: int 0
plugin........................: ptr 0x1ee8250
plugin_name...................: str 'python'
number........................: int 33
layout_number.................: int 0
layout_number_merge_order.....: int 0
name..........................: str 'networktocode.#general'
full_name.....................: str 'python.networktocode.#general'
short_name....................: str '#general'
type..........................: int 0
notify........................: int 3
num_displayed.................: int 0
active........................: int 1
hidden........................: int 0
zoomed........................: int 0
print_hooks_enabled...........: int 1
day_change....................: int 1
clear.........................: int 1
filter........................: int 1
closing.......................: int 0
first_line_not_read...........: int 0
lines_hidden..................: int 37
prefix_max_length.............: int 19
time_for_each_line............: int 1
nicklist_case_sensitive.......: int 0
nicklist_display_groups.......: int 1
nicklist_max_length...........: int 0
nicklist_count................: int 536
nicklist_groups_count.........: int 2
nicklist_nicks_count..........: int 534
nicklist_visible_count........: int 536
title.........................: str 'New people can join at http://slack.networktocode.com'
input.........................: int 1
input_get_unknown_commands....: int 0
input_get_empty...............: int 0
input_buffer..................: str ''
input_buffer_alloc............: int 256
input_buffer_size.............: int 0
input_buffer_length...........: int 0
input_buffer_pos..............: int 0
input_buffer_1st_display......: int 0
num_history...................: int 1
text_search...................: int 0
text_search_exact.............: int 0
text_search_regex.............: int 0
text_search_regex_compiled....: ptr
text_search_where.............: int 0
text_search_found.............: int 0
text_search_input.............: str ''
highlight_words...............: str ',U63MFLTH8,!everyone,!channel,@yeled,!here'
highlight_regex...............: str ''
highlight_regex_compiled......: ptr
highlight_tags_restrict.......: str ''
highlight_tags................: str ''
hotlist_max_level_nicks.......: str ''
keys_count....................: int 0
localvar_name_00000...........: str 'server'
localvar_value_00000..........: str 'networktocode'
localvar_name_00001...........: str 'script_input_cb'
localvar_value_00001..........: str 'buffer_input_callback'
localvar_name_00002...........: str 'script_name'
localvar_value_00002..........: str 'slack'
localvar_name_00003...........: str 'plugin'
localvar_value_00003..........: str 'python'
localvar_name_00004...........: str 'script_close_cb_data'
localvar_value_00004..........: str ''
localvar_name_00005...........: str 'type'
localvar_value_00005..........: str 'channel'
localvar_name_00006...........: str 'channel'
localvar_value_00006..........: str '#general'
localvar_name_00007...........: str 'nick'
localvar_value_00007..........: str 'yeled'
localvar_name_00008...........: str 'script_input_cb_data'
localvar_value_00008..........: str 'EVENTROUTER'
localvar_name_00009...........: str 'name'
localvar_value_00009..........: str 'networktocode.#general'
localvar_name_00010...........: str 'script_close_cb'
localvar_value_00010..........: str ''
```